### PR TITLE
Drop old docs template

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,5 +2,4 @@
     merge-mode: squash-merge
     default-branch: main
     templates:
-      - publish-otc-docs-pti
       - publish-otc-docs-hc-pti


### PR DESCRIPTION
We do not want to publish docs to other portal anymore
