### PR TITLE
add link to security advisory

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -86,5 +86,5 @@ latex_documents = [
 
 # -- Intersphinx
 intersphinx_mapping = {
-#    'otce': ('https://docs.otc-service.com/python-otcextensions', None)
+    'security': ('https://docs-beta.otc.t-systems.com/security', None)
 }

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -6,3 +6,4 @@ Quick Links
    Console <https://console.otc.t-systems.com>
    Health Dashboard <https://status.otc-service.com>
    Enterprise Dashboard <https://enterprise-dashboard.otc-service.com>
+   Security advisory <security/index>

--- a/doc/source/security/index.rst
+++ b/doc/source/security/index.rst
@@ -1,0 +1,6 @@
+Security Advisory
+=================
+
+This content will never be shown on real deployment, since we only need a
+redirect to /security, which will be processed by the reverse proxy and serve
+corresponding content.


### PR DESCRIPTION
We prepared /security project that is being fed from opentelekomcloud-docs/security repository. In order sphinx not to generate external link (open in new page) we make a fake folder with dummy index, which are only there to make sphinx build what we want