### PR TITLE
Hide not current l3+ entries

### DIFF
--- a/doc/source/_static/css/default.css
+++ b/doc/source/_static/css/default.css
@@ -47,3 +47,12 @@
 .navigator-container .card li {
   padding: 0.2rem 1rem;
 }
+
+/* A "nice" workaround to let us keep l2 level permanently open
+ * but hide child ul's not underneath current selection.
+ * The only eventually open issue is that this way the whole child tree is 
+ * open including all subtrees.
+ */
+.docs-sidebar-toc li.toctree-l2:not(.current) > ul {
+    display: none;
+}

--- a/doc/source/templates/sidebartoc.html
+++ b/doc/source/templates/sidebartoc.html
@@ -6,7 +6,7 @@
       {%- if theme_sidebar_mode == 'toc' %}
       {{ toc }}
       {%- elif theme_sidebar_mode == 'toctree' %}
-      {{ toctree(maxdepth=3,includehidden=True, collapse=False) }}
+      {{ toctree(maxdepth=4, includehidden=True, collapse=False, titles_only=True) }}
       {%- endif %}
     </div>
   {%- endif %}


### PR DESCRIPTION
In the sidebar we have a problem that we keep all tree open just to be
able to permanently show l2 level (services, developer, additional,
etc). This is causing us to also keep all the underlaying trees open as
well (Sphinx just does not let us do it differently). In order to have
possibility to simulate collapse of the not current elements in the tree
add a css hack that will hide subtree of not "current" l2 elements.
