### PR TITLE
Update third-party-sdk.rst - add Go SDK links

### DIFF
--- a/doc/source/developer/sdk/third-party-sdk.rst
+++ b/doc/source/developer/sdk/third-party-sdk.rst
@@ -14,3 +14,5 @@ Third-Party Software Development Kits (SDK)
 
       - Python SDK|https://github.com/opentelekomcloud-community/obs-python-sdk
       - Python SDK Documentation|https://docs.otc.t-systems.com/object-storage-service-3rd-party/python-sdk/
+      - Go SDK|https://github.com/opentelekomcloud-community/obs-go-sdk
+      - Go SDK Documentation|https://docs.otc.t-systems.com/object-storage-service-3rd-party/go-sdk/


### PR DESCRIPTION
This change is necessary for OBS Go SDK release.